### PR TITLE
updated authenticate method signature

### DIFF
--- a/oidc_rp/backends.py
+++ b/oidc_rp/backends.py
@@ -36,7 +36,7 @@ class OIDCAuthBackend(ModelBackend):
 
     """
 
-    def authenticate(self, nonce, request):
+    def authenticate(self, request, nonce=None, **kwargs):
         """ Authenticates users in case of the OpenID Connect Authorization code flow. """
         # NOTE: the request object is mandatory to perform the authentication using an authorization
         # code provided by the OIDC supplier.


### PR DESCRIPTION
In Django 2.1.1 the signature of base method is different. The first positional argument is the request. 

```
class ModelBackend:
    """
    Authenticates against settings.AUTH_USER_MODEL.
    """

    def authenticate(self, request, username=None, password=None, **kwargs):
```